### PR TITLE
fix 'connect to MySQL server‘

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ./etc/mysql/my.cnf:/etc/my.cnf
     environment:
       TZ: 'Asia/Shanghai'
+      DB_HOST: mysql
       MYSQL_ROOT_PASSWORD: password
   memcached:
     image: memcached


### PR DESCRIPTION
Failed to connect to your database server. The server reports the following message: SQLSTATE[HY000] [1130] Host 'IPaddress' is not allowed to connect to this MySQL server.